### PR TITLE
Updating the HDF5 Branch

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,38 @@
+%% Citations for WESTPA 2.0
+%% Includes the 2015 original paper and the 2022 WESTPA 2.0 paper
+%% Saved with string encoding Unicode (UTF-8) 
+
+@article{zwier_westpa_2015,
+	title = {{WESTPA}: {An} {Interoperable}, {Highly} {Scalable} {Software} {Package} for {Weighted} {Ensemble} {Simulation} and {Analysis}},
+	volume = {11},
+	issn = {1549-9618},
+	shorttitle = {{WESTPA}},
+	url = {https://doi.org/10.1021/ct5010615},
+	doi = {10.1021/ct5010615},
+	abstract = {The weighted ensemble (WE) path sampling approach orchestrates an ensemble of parallel calculations with intermittent communication to enhance the sampling of rare events, such as molecular associations or conformational changes in proteins or peptides. Trajectories are replicated and pruned in a way that focuses computational effort on underexplored regions of configuration space while maintaining rigorous kinetics. To enable the simulation of rare events at any scale (e.g., atomistic, cellular), we have developed an open-source, interoperable, and highly scalable software package for the execution and analysis of WE simulations: WESTPA (The Weighted Ensemble Simulation Toolkit with Parallelization and Analysis). WESTPA scales to thousands of CPU cores and includes a suite of analysis tools that have been implemented in a massively parallel fashion. The software has been designed to interface conveniently with any dynamics engine and has already been used with a variety of molecular dynamics (e.g., GROMACS, NAMD, OpenMM, AMBER) and cell-modeling packages (e.g., BioNetGen, MCell). WESTPA has been in production use for over a year, and its utility has been demonstrated for a broad set of problems, ranging from atomically detailed host–guest associations to nonspatial chemical kinetics of cellular signaling networks. The following describes the design and features of WESTPA, including the facilities it provides for running WE simulations and storing and analyzing WE simulation data, as well as examples of input and output.},
+	number = {2},
+	urldate = {2020-06-19},
+	journal = {Journal of Chemical Theory and Computation},
+	author = {Zwier, Matthew C. and Adelman, Joshua L. and Kaus, Joseph W. and Pratt, Adam J. and Wong, Kim F. and Rego, Nicholas B. and Suárez, Ernesto and Lettieri, Steven and Wang, David W. and Grabe, Michael and Zuckerman, Daniel M. and Chong, Lillian T.},
+	month = feb,
+	year = {2015},
+	pages = {800--809},
+}
+
+@article{russo_westpa_2022,
+	title = {{WESTPA} 2.0: {High}-{Performance} {Upgrades} for {Weighted} {Ensemble} {Simulations} and {Analysis} of {Longer}-{Timescale} {Applications}},
+	volume = {18},
+	copyright = {All rights reserved},
+	issn = {1549-9618},
+	shorttitle = {{WESTPA} 2.0},
+	url = {https://doi.org/10.1021/acs.jctc.1c01154},
+	doi = {10.1021/acs.jctc.1c01154},
+	abstract = {The weighted ensemble (WE) family of methods is one of several statistical mechanics-based path sampling strategies that can provide estimates of key observables (rate constants and pathways) using a fraction of the time required by direct simulation methods such as molecular dynamics or discrete-state stochastic algorithms. WE methods oversee numerous parallel trajectories using intermittent overhead operations at fixed time intervals, enabling facile interoperability with any dynamics engine. Here, we report on the major upgrades to the WESTPA software package, an open-source, high-performance framework that implements both basic and recently developed WE methods. These upgrades offer substantial improvements over traditional WE methods. The key features of the new WESTPA 2.0 software enhance the efficiency and ease of use: an adaptive binning scheme for more efficient surmounting of large free energy barriers, streamlined handling of large simulation data sets, exponentially improved analysis of kinetics, and developer-friendly tools for creating new WE methods, including a Python API and resampler module for implementing both binned and “binless” WE strategies.},
+	number = {2},
+	urldate = {2022-02-08},
+	journal = {Journal of Chemical Theory and Computation},
+	author = {Russo, John D. and Zhang, She and Leung, Jeremy M. G. and Bogetti, Anthony T. and Thompson, Jeff P. and DeGrave, Alex J. and Torrillo, Paul A. and Pratt, A. J. and Wong, Kim F. and Xia, Junchao and Copperman, Jeremy and Adelman, Joshua L. and Zwier, Matthew C. and LeBard, David N. and Zuckerman, Daniel M. and Chong, Lillian T.},
+	month = feb,
+	year = {2022},
+	pages = {638--649},
+}

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@
 WESTPA 2.0 
 ===============
 
-|ghactions| |docs|
+|ghactions| |anaconda| |tutorial1| |tutorial2| 
+
+|docs| |usersgroup| |develgroup| 
 
 .. |ghactions| image:: https://github.com/westpa/westpa/actions/workflows/test.yaml/badge.svg?branch=westpa-2.0-restruct
               :target: https://github.com/westpa/westpa/actions/workflows/test.yaml
@@ -11,6 +13,27 @@ WESTPA 2.0
 .. |docs| image:: https://readthedocs.org/projects/westpa/badge/?version=latest
          :target: https://westpa.readthedocs.io/en/latest/?badge=latest
          :alt: Documentation Status
+
+.. |tutorial1| image:: https://img.shields.io/badge/WESTPA-tutorials-brightgreen.svg
+        :target: https://github.com/westpa/westpa_tutorials 
+        :alt: WESTPA Tutorials GitHub
+
+.. |tutorial2| image:: https://img.shields.io/badge/WESTPA2-tutorials-blueviolet.svg
+        :target: https://github.com/westpa/westpa2_tutorials
+        :alt: WESTPA 2.0 Tutorials GitHub
+
+.. |usersgroup| image:: https://img.shields.io/badge/Google%20Group-Users-lightgrey.svg
+        :target: http://groups.google.com/group/westpa-users 
+        :alt: Users Google Group
+
+.. |develgroup| image:: https://img.shields.io/badge/Google%20Group-Developers-lightgrey.svg
+        :target: https://groups.google.com/g/westpa-devel 
+        :alt: Developers Google Group
+
+.. |anaconda| image:: https://anaconda.org/conda-forge/westpa/badges/version.svg
+   :alt: Anaconda
+   :target: https://anaconda.org/conda-forge/westpa
+
 
 --------
 Overview

--- a/src/westpa/cli/tools/plothist.py
+++ b/src/westpa/cli/tools/plothist.py
@@ -285,7 +285,7 @@ class PlotSupports2D(PlotHistBase):
         if self.plot_output_filename:
             if self.plotscale == 'energy':
                 plothist = enehist
-                label = r'$-\ln\,P(x)\ [kT^{-1}]$'
+                label = r'$-\ln\,P(x)$'
             elif self.plotscale == 'log10':
                 plothist = log10hist
                 label = r'$\log_{10}\ P(x)$'
@@ -322,7 +322,7 @@ class PlotSupports2D(PlotHistBase):
         if self.plot_output_filename:
             if self.plotscale == 'energy':
                 plothist = enehist
-                label = r'$-\ln\,P(x)\ [kT^{-1}]$'
+                label = r'$-\ln\,P(x)$'
             elif self.plotscale == 'log10':
                 plothist = log10hist
                 label = r'$\log_{10}\ P(\vec{x})$'
@@ -349,7 +349,7 @@ class PlotSupports2D(PlotHistBase):
                 ax, extent=(midpoints[0][0], midpoints[0][-1], midpoints[1][0], midpoints[1][-1]), origin='lower', norm=norm
             )
             nui.set_data(midpoints[0], midpoints[1], plothist.T)
-            ax.images.append(nui)
+            ax.add_image(nui)
             ax.set_xlim(midpoints[0][0], midpoints[0][-1])
             ax.set_ylim(midpoints[1][0], midpoints[1][-1])
             cb = pyplot.colorbar(nui)
@@ -628,7 +628,7 @@ probability distribution must have been previously extracted with ``w_pdist``
         if self.plot_output_filename:
             if self.plotscale == 'energy':
                 plothist = enehists
-                label = r'$-\ln\,P(x)\ [kT^{-1}]$'
+                label = r'$-\ln\,P(x)$'
             elif self.plotscale == 'log10':
                 plothist = log10hists
                 label = r'$\log_{10}\ P(x)$'
@@ -651,7 +651,7 @@ probability distribution must have been previously extracted with ``w_pdist``
             # not sure why plothist works but plothist.T doesn't, and the opposite is true
             # for _do_2d_output
             nui.set_data(midpoints, block_iters[:, -1], plothist)
-            ax.images.append(nui)
+            ax.add_image(nui)
             ax.set_xlim(midpoints[0], midpoints[-1])
             ax.set_ylim(block_iters[0, -1], block_iters[-1, -1])
             cb = pyplot.colorbar(nui)

--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -13,7 +13,7 @@ import numpy as np
 import westpa
 import westpa.core.data_manager
 from westpa.core.binning.assign import BinMapper
-from westpa.core.binning import RectilinearBinMapper, RecursiveBinMapper, MABBinMapper
+from westpa.core.binning import RectilinearBinMapper, RecursiveBinMapper, MABBinMapper, BinlessMapper
 from westpa.core.extloader import get_object
 from .yamlcfg import YAMLConfig
 from .yamlcfg import YAMLSystem
@@ -92,6 +92,21 @@ def detect_mab_mapper(mapper):
         for ibin in mapper._recursion_targets:
             rec_mapper = mapper._recursion_targets[ibin]
             if detect_mab_mapper(rec_mapper):
+                return True
+    else:
+        return False
+
+
+def detect_binless_mapper(mapper):
+    if isinstance(mapper, BinlessMapper):
+        return True
+    elif isinstance(mapper, RecursiveBinMapper):
+        if detect_binless_mapper(mapper.base_mapper):
+            return True
+
+        for ibin in mapper._recursion_targets:
+            rec_mapper = mapper._recursion_targets[ibin]
+            if detect_binless_mapper(rec_mapper):
                 return True
     else:
         return False
@@ -314,14 +329,28 @@ class WESTRC:
 
         return use_mab
 
+    def detect_binless_mapper(self):
+        bin_dict = self.config.get(['west', 'system', 'system_options', 'bins'])
+        use_binless = False
+        if bin_dict is not None:
+            mapper = bins_from_yaml_dict(bin_dict)
+            use_binless = detect_binless_mapper(mapper)
+
+        return use_binless
+
     def new_sim_manager(self):
         drivername = self.config.get(['west', 'drivers', 'sim_manager'], 'default')
         use_mab = self.detect_mab_mapper()
+        use_binless = self.detect_binless_mapper()
 
         if use_mab:
             from .binning.mab_manager import MABSimManager
 
             sim_manager = MABSimManager(rc=self)
+        elif use_binless:
+            from .binning.binless_manager import BinlessSimManager
+
+            sim_manager = BinlessSimManager(rc=self)
         elif drivername.lower() == 'default':
             from .sim_manager import WESimManager
 
@@ -358,11 +387,16 @@ class WESTRC:
 
         drivername = self.config.get(['west', 'drivers', 'we_driver'], 'default')
         use_mab = self.detect_mab_mapper()
+        use_binless = self.detect_binless_mapper()
 
         if use_mab:
             from .binning.mab_driver import MABDriver
 
             we_driver = MABDriver()
+        elif use_binless:
+            from .binning.binless_driver import BinlessDriver
+
+            we_driver = BinlessDriver()
         elif drivername.lower() == 'default':
             from .we_driver import WEDriver
 
@@ -371,21 +405,21 @@ class WESTRC:
             we_driver = extloader.get_object(drivername)(rc=self)
         log.debug('loaded WE algorithm driver: {!r}'.format(we_driver))
 
-        group_function = self.config.get(['west', 'drivers', 'group_function'], 'default')
-        if group_function.lower() == 'default':
+        subgroup_function = self.config.get(['west', 'drivers', 'subgroup_function'], 'default')
+        if subgroup_function.lower() == 'default':
             try:
-                group_function = 'westpa.core.we_driver._group_walkers_identity'
-                we_driver.group_function = westpa.core.we_driver._group_walkers_identity
+                subgroup_function = 'westpa.core.we_driver._group_walkers_identity'
+                we_driver.subgroup_function = westpa.core.we_driver._group_walkers_identity
             except Exception:
                 pass
         else:
-            we_driver.group_function = extloader.get_object(group_function)
-        we_driver.group_function_kwargs = self.config.get(['west', 'drivers', 'group_arguments'])
+            we_driver.subgroup_function = extloader.get_object(subgroup_function)
+        we_driver.subgroup_function_kwargs = self.config.get(['west', 'drivers', 'subgroup_arguments'])
         # Necessary if the user hasn't specified any options.
-        if we_driver.group_function_kwargs is None:
-            we_driver.group_function_kwargs = {}
-        log.debug('loaded WE algorithm driver grouping function {!r}'.format(group_function))
-        log.debug('WE algorithm driver grouping function kwargs: {!r}'.format(we_driver.group_function_kwargs))
+        if we_driver.subgroup_function_kwargs is None:
+            we_driver.subgroup_function_kwargs = {}
+        log.debug('loaded WE algorithm driver grouping function {!r}'.format(subgroup_function))
+        log.debug('WE algorithm driver grouping function kwargs: {!r}'.format(we_driver.subgroup_function_kwargs))
 
         return we_driver
 

--- a/src/westpa/core/_rc.py
+++ b/src/westpa/core/_rc.py
@@ -6,13 +6,14 @@ import math
 import os
 import sys
 import warnings
+from copy import deepcopy
 
 import numpy as np
 
 import westpa
 import westpa.core.data_manager
 from westpa.core.binning.assign import BinMapper
-from westpa.core.binning import RectilinearBinMapper, RecursiveBinMapper
+from westpa.core.binning import RectilinearBinMapper, RecursiveBinMapper, MABBinMapper
 from westpa.core.extloader import get_object
 from .yamlcfg import YAMLConfig
 from .yamlcfg import YAMLSystem
@@ -23,7 +24,7 @@ log = logging.getLogger('westpa.rc')
 
 
 def bins_from_yaml_dict(bin_dict):
-    kwargs = bin_dict.copy()
+    kwargs = deepcopy(bin_dict)
     typename = kwargs.pop('type')
 
     try:
@@ -79,6 +80,21 @@ def bins_from_yaml_dict(bin_dict):
         except Exception:
             log.exception('exception instantiating mapper')
             raise
+
+
+def detect_mab_mapper(mapper):
+    if isinstance(mapper, MABBinMapper):
+        return True
+    elif isinstance(mapper, RecursiveBinMapper):
+        if detect_mab_mapper(mapper.base_mapper):
+            return True
+
+        for ibin in mapper._recursion_targets:
+            rec_mapper = mapper._recursion_targets[ibin]
+            if detect_mab_mapper(rec_mapper):
+                return True
+    else:
+        return False
 
 
 def parsePCV(pc_str):
@@ -289,29 +305,30 @@ class WESTRC:
             except AttributeError:
                 pass
 
+    def detect_mab_mapper(self):
+        bin_dict = self.config.get(['west', 'system', 'system_options', 'bins'])
+        use_mab = False
+        if bin_dict is not None:
+            mapper = bins_from_yaml_dict(bin_dict)
+            use_mab = detect_mab_mapper(mapper)
+
+        return use_mab
+
     def new_sim_manager(self):
         drivername = self.config.get(['west', 'drivers', 'sim_manager'], 'default')
-        binmapname = self.config.get(['west', 'system', 'system_options', 'bins', 'type'], 'default')
+        use_mab = self.detect_mab_mapper()
 
-        try:
-            nestmapname = self.config.get(['west', 'system', 'system_options', 'bins', 'mappers'])[:][0]['type']
-        except TypeError:
-            nestmapname = binmapname
+        if use_mab:
+            from .binning.mab_manager import MABSimManager
 
-        if binmapname == 'MABBinMapper':
-            sim_manager = westpa.core.binning.mab_manager.MABSimManager(rc=self)
-            sys.stderr.write("-- WARNING  [config] -- Do not use MABBinMapper as an outer binning scheme with a target state.\n")
-
-        elif nestmapname == 'MABBinMapper':
-            sim_manager = westpa.core.binning.mab_manager.MABSimManager(rc=self)
-
+            sim_manager = MABSimManager(rc=self)
         elif drivername.lower() == 'default':
             from .sim_manager import WESimManager
 
             sim_manager = WESimManager(rc=self)
-
         else:
             sim_manager = extloader.get_object(drivername)(rc=self)
+
         log.debug('loaded simulation manager {!r}'.format(sim_manager))
         return sim_manager
 
@@ -340,22 +357,16 @@ class WESTRC:
         import westpa
 
         drivername = self.config.get(['west', 'drivers', 'we_driver'], 'default')
-        binmapname = self.config.get(['west', 'system', 'system_options', 'bins', 'type'], 'default')
+        use_mab = self.detect_mab_mapper()
 
-        try:
-            nestmapname = self.config.get(['west', 'system', 'system_options', 'bins', 'mappers'])[:][0]['type']
-        except TypeError:
-            nestmapname = None
+        if use_mab:
+            from .binning.mab_driver import MABDriver
 
-        if binmapname == 'MABBinMapper':
-            we_driver = westpa.core.binning.mab_driver.MABDriver()
-
-        elif nestmapname == 'MABBinMapper':
-            we_driver = westpa.core.binning.mab_driver.MABDriver()
-
+            we_driver = MABDriver()
         elif drivername.lower() == 'default':
-            we_driver = westpa.core.we_driver.WEDriver()
+            from .we_driver import WEDriver
 
+            we_driver = WEDriver()
         else:
             we_driver = extloader.get_object(drivername)(rc=self)
         log.debug('loaded WE algorithm driver: {!r}'.format(we_driver))

--- a/src/westpa/core/binning/__init__.py
+++ b/src/westpa/core/binning/__init__.py
@@ -12,9 +12,12 @@ from .assign import (
 )
 
 from .mab import map_mab, MABBinMapper
+from .binless import map_binless, BinlessMapper
 
 from .mab_driver import MABDriver
 from .mab_manager import MABSimManager
+from .binless_manager import BinlessSimManager
+from .binless_driver import BinlessDriver
 
 from ._assign import accumulate_labeled_populations, assign_and_label, accumulate_state_populations_from_labeled
 from ._assign import assignments_list_to_table
@@ -35,9 +38,13 @@ __all__ = [
     'VectorizingFuncBinMapper',
     'VoronoiBinMapper',
     'map_mab',
+    'map_binless',
     'MABBinMapper',
+    'BinlessMapper',
     'MABDriver',
     'MABSimManager',
+    'BinlessDriver',
+    'BinlessSimManager',
     'accumulate_labeled_populations',
     'assign_and_label',
     'accumulate_state_populations_from_labeled',

--- a/src/westpa/core/binning/binless.py
+++ b/src/westpa/core/binning/binless.py
@@ -1,0 +1,87 @@
+import numpy as np
+from westpa.core.binning import FuncBinMapper
+from westpa.core.extloader import get_object
+
+
+def map_binless(coords, mask, output, *args, **kwargs):
+    '''Adaptively groups walkers according to a user-defined grouping function
+    that is defined externally. Very general implementation but limited to
+    only a two dimensional progress coordinate (for now).'''
+
+    n_groups = kwargs.get("n_groups")
+    n_dims = kwargs.get("n_dims")
+    group_function = get_object(kwargs.get("group_function"))
+    ndim = n_dims
+
+    if not np.any(mask):
+        return output
+
+    allcoords = np.copy(coords)
+    allmask = np.copy(mask)
+
+    isfinal = None
+    splitting = False
+
+    # the segments should be sent in by the driver as half initial segments and half final segments
+    # allcoords contains all segments
+    # coords should contain ONLY final segments
+    if coords.shape[1] > ndim:
+        if coords.shape[1] > ndim + 1:
+            isfinal = allcoords[:, ndim + 1].astype(np.bool_)
+        else:
+            isfinal = np.ones(coords.shape[0], dtype=np.bool_)
+        coords = coords[isfinal, :ndim]
+        mask = mask[isfinal]
+        splitting = True
+
+    # in case where there is no final segments but initial ones in range
+    if not np.any(mask):
+        coords = allcoords[:, :ndim]
+        mask = allmask
+        splitting = False
+
+    # filter the list of coordinates (which contains coordinates outside of the binless region)
+    # to obtain only the ones we want to cluster
+    # this is done with all dimensions at once
+    binless_coords = coords[mask]
+    nsegs_binless = len(binless_coords)
+
+    # we need to make sure that the number of segments in the binless region is greater than
+    # the number of clusters we request
+    # if only one segment in the binless region, assign it to a single cluster
+    if nsegs_binless == 1:
+        clusters = [0]
+    # if there are more than one segment in the binless region but still the total is less than
+    # our target number, adjust our target number to be the number of segments in the binless
+    # region minus one
+    elif nsegs_binless < n_groups:
+        clusters = group_function(binless_coords, nsegs_binless, splitting)
+    # if there are enough segments in the binless region, proceed as planned
+    elif nsegs_binless >= n_groups:
+        clusters = group_function(binless_coords, n_groups, splitting)
+
+    # this is a good place to say this... output is a list which matches the length of allcoords
+    # allcoords is a collection of all initial and final segment coords for that iteration
+    # we first filtered those to only contain the final data points, since those are the ones we care
+    # about clustering
+    # we then filtered to only have the coords in the binless region, since, again, those are what we care about
+    # we then assigned each to a cluster which is essentially a slitting index
+    # all that's left is to find where each binless segment is in the output and insert the cluster index there
+    for idx, val in enumerate(binless_coords):
+        if ndim > 1:
+            mask2 = np.logical_and(allcoords[:, 0] == val[0], allcoords[:, 1] == val[1])
+        else:
+            mask2 = allcoords[:, 0] == val[0]
+        output[mask2] = clusters[idx]
+
+    return output
+
+
+class BinlessMapper(FuncBinMapper):
+    '''Adaptively group walkers according to a user-defined grouping
+    function that is defined externally.'''
+
+    def __init__(self, ngroups, ndims, group_function):
+        kwargs = dict(n_groups=ngroups, n_dims=ndims, group_function=group_function)
+        n_total_groups = ngroups
+        super().__init__(map_binless, n_total_groups, kwargs=kwargs)

--- a/src/westpa/core/binning/binless_driver.py
+++ b/src/westpa/core/binning/binless_driver.py
@@ -1,0 +1,53 @@
+import logging
+
+import numpy as np
+from westpa.core.we_driver import WEDriver
+
+log = logging.getLogger(__name__)
+
+
+class BinlessDriver(WEDriver):
+    def assign(self, segments, initializing=False):
+        '''Assign segments to initial and final bins, and update the (internal) lists of used and available
+        initial states. This function is adapted to the MAB scheme, so that the inital and final segments are
+        sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.'''
+
+        # collect initial and final coordinates into one place
+        n_segments = len(segments)
+        all_pcoords = np.empty((n_segments * 2, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)
+
+        for iseg, segment in enumerate(segments):
+            all_pcoords[iseg] = np.append(segment.pcoord[0, :], [segment.weight, 0.0])
+            all_pcoords[n_segments + iseg] = np.append(segment.pcoord[-1, :], [segment.weight, 1.0])
+
+        # assign based on initial and final progress coordinates
+        assignments = self.bin_mapper.assign(all_pcoords)
+        initial_assignments = assignments[:n_segments]
+        if initializing:
+            final_assignments = initial_assignments
+        else:
+            final_assignments = assignments[n_segments:]
+
+        initial_binning = self.initial_binning
+        final_binning = self.final_binning
+        flux_matrix = self.flux_matrix
+        transition_matrix = self.transition_matrix
+        for (segment, iidx, fidx) in zip(segments, initial_assignments, final_assignments):
+            initial_binning[iidx].add(segment)
+            final_binning[fidx].add(segment)
+            flux_matrix[iidx, fidx] += segment.weight
+            transition_matrix[iidx, fidx] += 1
+
+        n_recycled_total = self.n_recycled_segs
+        n_new_states = n_recycled_total - len(self.avail_initial_states)
+
+        log.debug(
+            '{} walkers scheduled for recycling, {} initial states available'.format(
+                n_recycled_total, len(self.avail_initial_states)
+            )
+        )
+
+        if n_new_states > 0:
+            return n_new_states
+        else:
+            return 0

--- a/src/westpa/core/binning/binless_manager.py
+++ b/src/westpa/core/binning/binless_manager.py
@@ -1,0 +1,73 @@
+import logging
+
+from westpa.core.sim_manager import WESimManager, grouper
+from westpa.core.states import InitialState, pare_basis_initial_states
+from westpa.core import wm_ops
+
+log = logging.getLogger(__name__)
+
+
+class BinlessSimManager(WESimManager):
+    def report_bin_statistics(self, bins, save_summary=False):
+        self.rc.pstatus("Binless scheme in use.")
+        super().report_bin_statistics(bins, save_summary)
+
+    def propagate(self):
+        segments = list(self.incomplete_segments.values())
+        log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
+
+        # all futures dispatched for this iteration
+        futures = set()
+        segment_futures = set()
+
+        # Immediately dispatch any necessary initial state generation
+        istate_gen_futures = self.get_istate_futures()
+        futures.update(istate_gen_futures)
+
+        # Dispatch propagation tasks using work manager
+        for segment_block in grouper(self.propagator_block_size, segments):
+            segment_block = [_f for _f in segment_block if _f]
+            pbstates, pistates = pare_basis_initial_states(
+                self.current_iter_bstates, list(self.current_iter_istates.values()), segment_block
+            )
+            future = self.work_manager.submit(wm_ops.propagate, args=(pbstates, pistates, segment_block))
+            futures.add(future)
+            segment_futures.add(future)
+
+        while futures:
+            # TODO: add capacity for timeout or SIGINT here
+            future = self.work_manager.wait_any(futures)
+            futures.remove(future)
+
+            if future in segment_futures:
+                segment_futures.remove(future)
+                incoming = future.get_result()
+                self.n_propagated += 1
+
+                self.segments.update({segment.seg_id: segment for segment in incoming})
+                self.completed_segments.update({segment.seg_id: segment for segment in incoming})
+
+                new_istate_futures = self.get_istate_futures()
+                istate_gen_futures.update(new_istate_futures)
+                futures.update(new_istate_futures)
+
+                with self.data_manager.expiring_flushing_lock():
+                    self.data_manager.update_segments(self.n_iter, incoming)
+
+            elif future in istate_gen_futures:
+                istate_gen_futures.remove(future)
+                _basis_state, initial_state = future.get_result()
+                log.debug('received newly-prepared initial state {!r}'.format(initial_state))
+                initial_state.istate_status = InitialState.ISTATE_STATUS_PREPARED
+                with self.data_manager.expiring_flushing_lock():
+                    self.data_manager.update_initial_states([initial_state], n_iter=self.n_iter + 1)
+                self.we_driver.avail_initial_states[initial_state.state_id] = initial_state
+            else:
+                log.error('unknown future {!r} received from work manager'.format(future))
+                raise AssertionError('untracked future {!r}'.format(future))
+
+        self.we_driver.assign(self.segments.values())
+        self.get_istate_futures()
+        log.debug('done with propagation')
+        self.save_bin_data()
+        self.data_manager.flush_backing()

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -1,5 +1,6 @@
 import numpy as np
 from westpa.core.binning import FuncBinMapper
+import westpa
 
 
 def map_mab(coords, mask, output, *args, **kwargs):
@@ -111,11 +112,13 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     flipmaxdiff = flipdiff
 
     if splitting:
-        print("####### MAB stats #######")
-        print("minima in each dimension:", minlist)
-        print("maxima in each dimension:", maxlist)
-        print("direction for each dimension:", direction)
-        print("#########################")
+        westpa.rc.pstatus("################ MAB stats ################")
+        westpa.rc.pstatus("minima in each dimension:      {}".format(minlist))
+        westpa.rc.pstatus("maxima in each dimension:      {}".format(maxlist))
+        westpa.rc.pstatus("direction in each dimension:   {}".format(direction))
+        westpa.rc.pstatus("###########################################")
+        westpa.rc.pflush()
+
     # assign segments to bins
     # the total number of linear bins + 2 boundary bins each dim
     boundary_base = np.prod(nbins_per_dim)

--- a/src/westpa/core/binning/mab.py
+++ b/src/westpa/core/binning/mab.py
@@ -11,8 +11,15 @@ def map_mab(coords, mask, output, *args, **kwargs):
 
     pca = kwargs.pop("pca", False)
     bottleneck = kwargs.pop("bottleneck", True)
-    nbins_per_dim = kwargs.get("nbins_per_dim")
+    direction = kwargs.pop("direction", None)
+    nbins_per_dim = kwargs.pop("nbins_per_dim")
+
+    if nbins_per_dim is None:
+        raise ValueError("nbins_per_dim is missing")
+
     ndim = len(nbins_per_dim)
+    if direction is None:
+        direction = [0] * ndim
 
     if not np.any(mask):
         return output
@@ -51,7 +58,7 @@ def map_mab(coords, mask, output, *args, **kwargs):
         for i in range(len(coords)):
             for j in range(len(coords[i])):
                 varcoords[i][j] = coords[i][j] - colavg[j]
-        covcoords = np.cov(np.transpose(varcoords))
+        covcoords = np.cov(np.transpose(varcoords), aweights=weights)
         eigval, eigvec = np.linalg.eigh(covcoords)
         eigvec = eigvec[:, np.argmax(np.absolute(eigvec), axis=1)]
         for i in range(len(eigvec)):
@@ -103,6 +110,12 @@ def map_mab(coords, mask, output, *args, **kwargs):
                     flipdifflist[n] = fliptemp[i][0]
                     flipmaxdiff = flipdiff
 
+    if splitting:
+        print("####### MAB stats #######")
+        print("minima in each dimension:", minlist)
+        print("maxima in each dimension:", maxlist)
+        print("direction for each dimension:", direction)
+        print("#########################")
     # assign segments to bins
     # the total number of linear bins + 2 boundary bins each dim
     boundary_base = np.prod(nbins_per_dim)
@@ -126,14 +139,28 @@ def map_mab(coords, mask, output, *args, **kwargs):
                         holder = bottleneck_base + 2 * n + 1
                         special = True
                         break
-                if coord == minlist[n]:
-                    holder = boundary_base + 2 * n
-                    special = True
-                    break
-                elif coord == maxlist[n]:
-                    holder = boundary_base + 2 * n + 1
-                    special = True
-                    break
+
+                if direction[n] < 0:
+                    if coord == minlist[n]:
+                        holder = boundary_base + 2 * n
+                        special = True
+                        break
+
+                elif direction[n] > 0:
+                    if coord == maxlist[n]:
+                        holder = boundary_base + 2 * n
+                        special = True
+                        break
+
+                elif direction[n] == 0:
+                    if coord == minlist[n]:
+                        holder = boundary_base + 2 * n
+                        special = True
+                        break
+                    elif coord == maxlist[n]:
+                        holder = boundary_base + 2 * n + 1
+                        special = True
+                        break
 
         if not special:
             for n in range(ndim):
@@ -145,13 +172,10 @@ def map_mab(coords, mask, output, *args, **kwargs):
                 bins = np.linspace(minp, maxp, nbins + 1)
                 bin_number = np.digitize(coord, bins) - 1
 
-                if isfinal is None or not isfinal[i]:
-                    if bin_number >= nbins:
-                        bin_number = nbins - 1
-                    elif bin_number < 0:
-                        bin_number = 0
-                elif bin_number >= nbins or bin_number < 0:
-                    raise ValueError("Walker out of boundary")
+                if bin_number >= nbins:
+                    bin_number = nbins - 1
+                elif bin_number < 0:
+                    bin_number = 0
 
                 holder += bin_number * np.prod(nbins_per_dim[:n])
 
@@ -165,8 +189,8 @@ class MABBinMapper(FuncBinMapper):
     the progress coordinte. Extrema and bottleneck segments are assigned
     to their own bins.'''
 
-    def __init__(self, nbins, bottleneck=True, pca=False):
-        kwargs = dict(nbins_per_dim=nbins, bottleneck=bottleneck, pca=pca)
+    def __init__(self, nbins, direction=None, bottleneck=True, pca=False):
+        kwargs = dict(nbins_per_dim=nbins, direction=direction, bottleneck=bottleneck, pca=pca)
         ndim = len(nbins)
         n_total_bins = np.prod(nbins) + ndim * (2 + 2 * bottleneck)
         super().__init__(map_mab, n_total_bins, kwargs=kwargs)

--- a/src/westpa/core/binning/mab_driver.py
+++ b/src/westpa/core/binning/mab_driver.py
@@ -12,6 +12,7 @@ class MABDriver(WEDriver):
         initial states. This function is adapted to the MAB scheme, so that the inital and final segments are
         sent to the bin mapper at the same time, otherwise the inital and final bin boundaries can be inconsistent.'''
 
+        log.debug("MABDriver in use.")
         # collect initial and final coordinates into one place
         n_segments = len(segments)
         all_pcoords = np.empty((n_segments * 2, self.system.pcoord_ndim + 2), dtype=self.system.pcoord_dtype)

--- a/src/westpa/core/binning/mab_manager.py
+++ b/src/westpa/core/binning/mab_manager.py
@@ -1,5 +1,6 @@
 import logging
 
+from westpa.core.binning.mab import MABBinMapper
 from westpa.core.sim_manager import WESimManager, grouper
 from westpa.core.states import InitialState, pare_basis_initial_states
 from westpa.core import wm_ops
@@ -8,11 +9,21 @@ log = logging.getLogger(__name__)
 
 
 class MABSimManager(WESimManager):
+    def initialize_simulation(self, basis_states, target_states, start_states, segs_per_state=1, suppress_we=False):
+        if len(target_states) > 0:
+            if isinstance(self.system.bin_mapper, MABBinMapper):
+                log.error("MABBinMapper cannot be an outer binning scheme with a target state.\n")
+
+        super().initialize_simulation(
+            basis_states, target_states, start_states, segs_per_state=segs_per_state, suppress_we=suppress_we
+        )
+
     def report_bin_statistics(self, bins, save_summary=False):
         self.rc.pstatus("MAB binning in use.")
         super().report_bin_statistics(bins, save_summary)
 
     def propagate(self):
+        log.debug("MABSimManager in use.")
         segments = list(self.incomplete_segments.values())
         log.debug('iteration {:d}: propagating {:d} segments'.format(self.n_iter, len(segments)))
 

--- a/src/westpa/core/h5io.py
+++ b/src/westpa/core/h5io.py
@@ -693,7 +693,7 @@ class WESTIterationFile(HDF5TrajectoryFile):
         # restart
         if restart is not None:
             if self.has_restart(segment):
-                self._remove_node('/restart', name='%d_%d' % (segment.n_iter, segment.seg_id))
+                self._remove_node('/restart', name='%d_%d' % (segment.n_iter, segment.seg_id), recursive=True)
 
             self._create_array(
                 '/restart/%d_%d' % (segment.n_iter, segment.seg_id),
@@ -705,7 +705,7 @@ class WESTIterationFile(HDF5TrajectoryFile):
 
         if slog is not None:
             if self._has_node('/log', str(segment.seg_id)):
-                self._remove_node('/log', name=str(segment.seg_id))
+                self._remove_node('/log', name=str(segment.seg_id), recursive=True)
 
             self._create_array(
                 '/log/%d_%d' % (segment.n_iter, segment.seg_id),

--- a/src/westpa/core/kinetics/events.py
+++ b/src/westpa/core/kinetics/events.py
@@ -114,13 +114,14 @@ class WKinetics:
 
             # Estimate macrostate fluxes and calculate event durations using trajectory tracing
             # state is opaque to the find_macrostate_transitions function
+            dt = 1.0 if npts == 1 else 1.0 / (npts - 1)
             state = _fast_transition_state_copy(iiter, nstates, parent_ids, last_state)
             find_macrostate_transitions(
                 nstates,
                 weights,
                 label_assignments,
                 state_assignments,
-                1.0 / (npts - 1),
+                dt,
                 state,
                 cond_fluxes,
                 cond_counts,

--- a/src/westpa/core/propagators/executable.py
+++ b/src/westpa/core/propagators/executable.py
@@ -46,8 +46,8 @@ def pcoord_loader(fieldname, pcoord_return_filename, destobj, single_point):
             pcoord.shape = (1,)
     else:
         expected_shape = (system.pcoord_len, system.pcoord_ndim)
-        if pcoord.ndim == 1:
-            pcoord.shape = (len(pcoord), 1)
+        if pcoord.ndim < 2:
+            pcoord.shape = expected_shape
     if pcoord.shape != expected_shape:
         raise ValueError(
             'progress coordinate data has incorrect shape {!r} [expected {!r}] Check pcoord.err or seg_logs for more information.'.format(

--- a/src/westpa/core/sim_manager.py
+++ b/src/westpa/core/sim_manager.py
@@ -90,11 +90,6 @@ class WESimManager:
         self.next_iter_bstates = None  # BasisStates valid for the next iteration
         self.next_iter_bstate_cprobs = None  # Cumulative probabilities for basis states, used for selection
 
-        # Initial states for next iteration
-        # self.next_iter_istates = None
-        # self.next_iter_avail_istates = None    # InitialStates available for use next iteration
-        # self.next_iter_assigned_istates = None # InitialStates that were available or generated in this iteration but then used
-
         # Tracking of this iteration's segments
         self.segments = None  # Mapping of seg_id to segment for all segments in this iteration
         self.completed_segments = None  # Mapping of seg_id to segment for all completed segments in this iteration
@@ -196,6 +191,11 @@ class WESimManager:
         self.rc.pstatus('per-segment probability dynamic range (kT): {:g}'.format(seg_drange))
         self.rc.pstatus('norm = {:g}, error in norm = {:g} ({:.2g}*epsilon)'.format(norm, (norm - 1), (norm - 1) / EPS))
         self.rc.pflush()
+
+        if min_seg_prob < 1e-100:
+            log.warning(
+                '\n Minimum segment weight is < 1e-100 and might not be physically relevant. Please reconsider your progress coordinate or binning scheme.'
+            )
 
         if save_summary:
             iter_summary = self.data_manager.get_iter_summary()

--- a/src/westpa/core/yamlcfg.py
+++ b/src/westpa/core/yamlcfg.py
@@ -157,7 +157,7 @@ class YAMLConfig:
     def __contains__(self, key):
         try:
             self[key]
-        except KeyError:
+        except (KeyError, TypeError):
             return False
         else:
             return True

--- a/src/westpa/westext/wess/wess_driver.py
+++ b/src/westpa/westext/wess/wess_driver.py
@@ -92,7 +92,6 @@ class WESSDriver:
                 eff_windowsize = min(self.max_windowsize, int(n_iter * self.windowsize))
             else:
                 eff_windowsize = int(n_iter * self.windowsize)
-
         else:  # self.windowtype == 'fixed':
             eff_windowsize = min(n_iter, self.windowsize or 0)
 

--- a/tests/test_we_driver.py
+++ b/tests/test_we_driver.py
@@ -196,7 +196,7 @@ class TestWEDriver(TestCase):
 
         for ibin, bin in enumerate(self.we_driver.next_iter_binning):
             target_count = self.we_driver.bin_target_counts[ibin]
-            groups = self.we_driver.group_function(self.we_driver, ibin, **self.we_driver.group_function_kwargs)
+            groups = self.we_driver.subgroup_function(self.we_driver, ibin, **self.we_driver.subgroup_function_kwargs)
             self.we_driver._adjust_count(bin, groups, target_count)
 
         assert len(self.we_driver.next_iter_binning[0]) == 5


### PR DESCRIPTION
Most of it are from pulling the most recent changes from the upstream `westpa-2.0-restruct` branch.

This includes a bug fix for `src/westpa/core/h5io.py` where certain pytable nodes are unable to be removed because recursive mode is not specified.  Error should be reproducible when running `w_init` twice without actually deleting your old h5 files. This fixes that.